### PR TITLE
fix article move him to another department

### DIFF
--- a/src/localization/experiences/en.json
+++ b/src/localization/experiences/en.json
@@ -49,7 +49,7 @@
           "link": {
             "href": "/experiences/just_move_him",
             "name": "Read story",
-            "state": "coming soon"
+            "state": "Read article"
           },
           "image": {
             "href": "/images/experiences/just_move_him.png",


### PR DESCRIPTION
der artikel "Just move him to another departement" ist derzeit noch nicht aufrufbar. kann es sein, dass das an dem state liegt? Lokal geht es dann, aber ich blicke nicht wie das alles zusammen hängt. Hab ich noch was übersehen?